### PR TITLE
02-C-02: feat: add password visibility icon and id attribute; fix: input-block width in base input component

### DIFF
--- a/src/components/shared/BaseInput.vue
+++ b/src/components/shared/BaseInput.vue
@@ -4,7 +4,7 @@
       label
     }}</label>
     <input
-      :type="currentInputType"
+      :type="type"
       :id="id"
       :placeholder="name ? name : ''"
       v-model.trim="inputValue"
@@ -17,8 +17,8 @@
       :disabled="disabled"
       ref="input"
     />
-    <EyeIcon v-if="showPass === 'hide'" class="input-icon" />
-    <EyeSlashIcon v-if="showPass === 'show'" class="input-icon" />
+    <EyeIcon v-if="hidePass === 'show'" class="input-icon" />
+    <EyeSlashIcon v-if="hidePass === 'hide'" class="input-icon" />
   </div>
 </template>
 
@@ -41,7 +41,7 @@ export default {
       type: String,
       default: '',
     },
-    inputType: {
+    type: {
       type: String,
       default: 'text',
     },
@@ -69,17 +69,9 @@ export default {
       type: String,
       default: '',
     },
-    showPass: {
+    hidePass: {
       type: String,
       default: '',
-    },
-  },
-  computed: {
-    currentInputType(): string {
-      if (this.showPass === '' || this.showPass === 'show') {
-        return this.inputType;
-      }
-      return 'password';
     },
   },
 };

--- a/src/components/tests/BaseInput.test.ts
+++ b/src/components/tests/BaseInput.test.ts
@@ -94,7 +94,7 @@ describe('Password visibility icon', () => {
     const wrapper = mount(BaseInput, {
       props: {
         id: 'story',
-        showPass: 'hide',
+        hidePass: 'hide',
       },
     });
     expect(wrapper.find('svg.input-icon').exists()).toBeTruthy();
@@ -103,7 +103,7 @@ describe('Password visibility icon', () => {
     const wrapper = mount(BaseInput, {
       props: {
         id: 'story',
-        showPass: 'show',
+        hidePass: 'show',
       },
     });
     expect(wrapper.find('svg.input-icon').exists()).toBeTruthy();
@@ -115,7 +115,8 @@ describe('Input type password', () => {
     const wrapper = mount(BaseInput, {
       props: {
         id: 'story',
-        showPass: 'hide',
+        type: 'password',
+        hidePass: 'hide',
       },
     });
     expect(wrapper.find('input').element.type === 'password').toBeTruthy();
@@ -124,7 +125,7 @@ describe('Input type password', () => {
     const wrapper = mount(BaseInput, {
       props: {
         id: 'story',
-        showPass: 'show',
+        hidePass: 'show',
       },
     });
     expect(wrapper.find('input').element.type === 'text').toBeTruthy();

--- a/src/stories/BaseInput.stories.ts
+++ b/src/stories/BaseInput.stories.ts
@@ -60,15 +60,15 @@ export const InvalidValue: Story = {
 export const PasswordHide: Story = {
   args: {
     id: 'story_seven',
-    inputType: 'password',
-    showPass: 'hide',
+    type: 'password',
+    hidePass: 'show',
   },
 };
 
 export const PasswordShown: Story = {
   args: {
     id: 'story_eight',
-    inputType: 'text',
-    showPass: 'show',
+    type: 'text',
+    hidePass: 'hide',
   },
 };


### PR DESCRIPTION
#### 😉 Purpose of the pull request

- [x] New feature
- [x] Bug fix
- [x] Test Case

#### 🎑 Screenshots

<img width="620" alt="SCR-20230815-opka" src="https://github.com/Wystov/ecommerce-app/assets/101750257/a5a6eb7e-ec65-4741-a03b-0c2cca42fd6b">

#### 🔗 Description

- Add visibility icon and showPass prop in base input component;
- Add id prop;
- Change type prop name (type => inputType);
- Fix width bug in component;
- Fix test for render component with random width;
- Add new stories for different styles of input with password type in storybook;
- Add new tests for new functionality.

Note: 
- I didn't add complete logic for visibility changing, cause it's not possible to change props inside the component itself. I added all necessary settings though. There is a prop to control visibility - showPass, which can be 'hide' or 'show' in password input type case. Visibility of the icon depend on the property icon, which takes a name of the icon file as a value.

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Documentation is updated/provided or not needed
- [x] New code does not break existing tests.
- [x] Before creating pull request, the development branch has been merged into this branch, and any conflicts have been resolved.
